### PR TITLE
build(package): update peerDependencies to support typedoc@0.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "typescript": "5.0.4"
       },
       "peerDependencies": {
-        "typedoc": "^0.23"
+        "typedoc": "0.23 || 0.24"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "5.0.4"
   },
   "peerDependencies": {
-    "typedoc": "^0.23"
+    "typedoc": "0.23 || 0.24"
   },
   "files": [
     "lib/"


### PR DESCRIPTION
Release-As: 1.0.1

## What is the motivation for this pull request?

build(package): update peerDependencies to support typedoc@0.24

## What is the current behavior?

peerDependencies only support typedoc@0.23

This causes errors when trying to upgrade typedoc:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: typedoc-plugin-copy-code-to-clipboard@1.0.0
npm ERR! Found: typedoc@0.24.4
npm ERR! node_modules/typedoc
npm ERR!   dev typedoc@"0.24.4" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer typedoc@"^0.23" from typedoc-plugin-copy-code-to-clipboard@1.0.0
npm ERR! node_modules/typedoc-plugin-copy-code-to-clipboard
npm ERR!   dev typedoc-plugin-copy-code-to-clipboard@"1.0.0" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: typedoc@0.23.28
npm ERR! node_modules/typedoc
npm ERR!   peer typedoc@"^0.23" from typedoc-plugin-copy-code-to-clipboard@1.0.0
npm ERR!   node_modules/typedoc-plugin-copy-code-to-clipboard
npm ERR!     dev typedoc-plugin-copy-code-to-clipboard@"1.0.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

## What is the new behavior?

peerDependencies support typedoc 0.23 and 0.24

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation