### PR TITLE
fix: render script if typedoc is >=0.24.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Note**: TypeDoc natively supports this in [TypeStrong/typedoc#2153](https://github.com/TypeStrong/typedoc/issues/2153)
+> **Note**: TypeDoc natively supports this in [v0.24.5](https://github.com/TypeStrong/typedoc/issues/2153)
 
 # typedoc-plugin-copy-code-to-clipboard
 

--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`load renders markup on "body.end" for typedoc v0.24.4 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "children": [],
+          "props": {
+            "html": "style",
+          },
+          "tag": [Function],
+        },
+      ],
+      "props": null,
+      "tag": "style",
+    },
+    {
+      "children": [
+        {
+          "children": [],
+          "props": {
+            "html": "(function(){scriptundefined();})();",
+          },
+          "tag": [Function],
+        },
+      ],
+      "props": null,
+      "tag": "script",
+    },
+  ],
+  "props": null,
+  "tag": Symbol(),
+}
+`;
+
+exports[`load renders markup on "body.end" for typedoc v0.24.5 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "children": [],
+          "props": {
+            "html": "style",
+          },
+          "tag": [Function],
+        },
+      ],
+      "props": null,
+      "tag": "style",
+    },
+    false,
+  ],
+  "props": null,
+  "tag": Symbol(),
+}
+`;

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,22 +1,35 @@
-import type { Application } from 'typedoc';
+import { Application } from 'typedoc';
 
 import { load } from '../src/index';
 
+jest.mock('../src/script', () => 'script');
+jest.mock('../src/style', () => 'style');
+
+const { VERSION } = Application;
+
+afterAll(() => {
+  Application.VERSION = VERSION;
+});
+
 describe('load', () => {
-  it('calls hook "body.end" with callback', () => {
-    const app = {
-      renderer: {
-        hooks: {
-          on: jest.fn(),
+  it.each(['0.24.4', '0.24.5'])(
+    'renders markup on "body.end" for typedoc v%s',
+    (version) => {
+      Application.VERSION = version;
+      const app = {
+        renderer: {
+          hooks: {
+            on: jest.fn(),
+          },
         },
-      },
-    };
-    expect(load(app as unknown as Application)).toBe(undefined);
-    expect(app.renderer.hooks.on).toBeCalledTimes(1);
-    expect(app.renderer.hooks.on).toBeCalledWith(
-      'body.end',
-      expect.any(Function)
-    );
-    expect(app.renderer.hooks.on.mock.calls[0][1]()).toBeTruthy();
-  });
+      };
+      expect(load(app as unknown as Application)).toBe(undefined);
+      expect(app.renderer.hooks.on).toBeCalledTimes(1);
+      expect(app.renderer.hooks.on).toBeCalledWith(
+        'body.end',
+        expect.any(Function)
+      );
+      expect(app.renderer.hooks.on.mock.calls[0][1]()).toMatchSnapshot();
+    }
+  );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.0"
+      },
       "devDependencies": {
         "@commitlint/cli": "17.6.3",
         "@commitlint/config-conventional": "17.6.3",
@@ -28,11 +31,11 @@
         "prettier": "2.8.8",
         "standard-version": "9.5.0",
         "ts-jest": "29.1.0",
-        "typedoc": "0.24.1",
+        "typedoc": "0.24.7",
         "typescript": "5.0.4"
       },
       "peerDependencies": {
-        "typedoc": "0.23 || 0.24"
+        "typedoc": "^0.24.7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5868,9 +5871,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -6861,7 +6864,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6874,7 +6876,6 @@
     },
     "node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -6885,7 +6886,6 @@
     },
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -7626,14 +7626,14 @@
       "license": "MIT"
     },
     "node_modules/typedoc": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.1.tgz",
-      "integrity": "sha512-u4HwjZcSQhQSkkhLjgcs0ooAf6HrFVLDHHrwU2xZW8WxH0KnGZlNkaWxiOcK5Gagj7mxJSgwWx0dv8ACDAOXAQ==",
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.7.tgz",
+      "integrity": "sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
         "shiki": "^0.14.1"
       },
       "bin": {
@@ -7656,15 +7656,15 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -12148,9 +12148,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
     },
     "meow": {
@@ -12758,21 +12758,18 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0",
-          "dev": true
+          "version": "4.0.0"
         }
       }
     },
@@ -13260,14 +13257,14 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.1.tgz",
-      "integrity": "sha512-u4HwjZcSQhQSkkhLjgcs0ooAf6HrFVLDHHrwU2xZW8WxH0KnGZlNkaWxiOcK5Gagj7mxJSgwWx0dv8ACDAOXAQ==",
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.7.tgz",
+      "integrity": "sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
         "shiki": "^0.14.1"
       },
       "dependencies": {
@@ -13281,9 +13278,9 @@
           }
         },
         "minimatch": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+          "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "code block",
     "clipboard"
   ],
+  "dependencies": {
+    "semver": "^7.5.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "17.6.3",
     "@commitlint/config-conventional": "17.6.3",
@@ -53,11 +56,11 @@
     "prettier": "2.8.8",
     "standard-version": "9.5.0",
     "ts-jest": "29.1.0",
-    "typedoc": "0.24.1",
+    "typedoc": "0.24.7",
     "typescript": "5.0.4"
   },
   "peerDependencies": {
-    "typedoc": "0.23 || 0.24"
+    "typedoc": "^0.24.7"
   },
   "files": [
     "lib/"

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+DOCS_DIRECTORY='docs'
+
+npm run docs
+
+# https://developers.cloudflare.com/pages/platform/build-configuration/#environment-variables
+if [[ $CF_PAGES == '1' ]]; then
+  # https://community.cloudflare.com/t/functions-dir-is-ignored-in-deploy/438211
+  # https://github.com/cloudflare/wrangler2/issues/2240#issuecomment-1343406897
+  FUNCTIONS='functions/'
+  RENAMED_FUNCTIONS='function/'
+  FUNCTIONS_DIRECTORY="$DOCS_DIRECTORY/$FUNCTIONS"
+  RENAMED_FUNCTIONS_DIRECTORY="$DOCS_DIRECTORY/$RENAMED_FUNCTIONS"
+
+  mv $FUNCTIONS_DIRECTORY $RENAMED_FUNCTIONS_DIRECTORY
+
+  if [[ $(uname) == 'Linux' ]]; then
+    sed -i "s|$FUNCTIONS|$RENAMED_FUNCTIONS|g" $DOCS_DIRECTORY/*.html
+    sed -i "s|$FUNCTIONS|$RENAMED_FUNCTIONS|g" $DOCS_DIRECTORY/assets/search.js
+  elif [[ $(uname) == 'Darwin' ]]; then
+    sed -i '' "s|$FUNCTIONS|$RENAMED_FUNCTIONS|g" $DOCS_DIRECTORY/*.html
+    sed -i '' "s|$FUNCTIONS|$RENAMED_FUNCTIONS|g" $DOCS_DIRECTORY/assets/search.js
+  fi
+
+  echo "Renamed $FUNCTIONS_DIRECTORY to $RENAMED_FUNCTIONS_DIRECTORY"
+fi

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
-import type { Application } from 'typedoc';
+import semver from 'semver';
+import { Application } from 'typedoc';
 import { JSX } from 'typedoc';
 
 import script from './script';
@@ -11,15 +12,20 @@ import { iife } from './utils';
  * @param app - Reference to the application that is loading the plugin.
  */
 export function load(app: Application): void {
+  // https://github.com/TypeStrong/typedoc/issues/2153
+  const hasNativeSupport = semver.gte(Application.VERSION, '0.24.5');
+
   app.renderer.hooks.on('body.end', () => (
     <>
       <style>
         <JSX.Raw html={style.trim()} />
       </style>
 
-      <script>
-        <JSX.Raw html={iife(script)} />
-      </script>
+      {!hasNativeSupport && (
+        <script>
+          <JSX.Raw html={iife(script)} />
+        </script>
+      )}
     </>
   ));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "lib": ["dom"],
     "declaration": true,


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: render script if typedoc is >=0.24.5

https://github.com/TypeStrong/typedoc/issues/2153

## What is the current behavior?

Copy button is messing up typedoc's native copy feature (it ends up saving `Copy` to the clipboard)

## What is the new behavior?

Don't render copy script if typedoc version is greater than or equal to `0.24.5` (only styling will be rendered)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation